### PR TITLE
Split trial result from configuration

### DIFF
--- a/src/EcoTrialStructure.jl
+++ b/src/EcoTrialStructure.jl
@@ -5,10 +5,11 @@ You can learn more about each of the following from its own docstring, e.g., `?C
 
 - `CellsTrial`: Store cellular responses for a single trial.
 - `EventTiming`: Specify the timing of events during a trial.
-- `FrameSeq`: A sequence of `nframes` frames starting at the nearest timepoint to `tstart`.
-- `TrialType`: Encode the offers (`nA` and `nB` are the number of drops of A and B, respectively), whether A was on the left, and whether the animal chose A, B, or failed to make a choice (`choseA = true | false | missing`, respectively).
-- `isforced`: Returns `true` for a forced-choice trial, where either `nA` or `nB` is zero.
-- `iswrong`: Returns `true` if `tt` is a forced-choice trial and the animal chose the wrong option.
+- `FrameSeq`: A sequence of `nframes` frames starting nearest to a specified time.
+- `TrialType`: Encode the offer quantities and side (left/right).
+- `TrialResult`: Encode the `TrialType` and the animal's choice.
+- `isforced`: Returns `true` for a forced-choice trial.
+- `iswrong`: Returns `true` if the animal chose incorrectly on a forced-choice trial.
 - `madechoice`: Returns `true` if the animal made a choice in the trial.
 - `parsemat`: Parse the trial data in `filename`.
 - `positive_cells`: Extract the vector of `idx_positive_cells` from the .mat file.
@@ -20,7 +21,7 @@ using Unitful: ms, s
 using IntervalSets
 using MAT
 
-export CellsTrial, FrameSeq, TrialType, EventTiming
+export CellsTrial, FrameSeq, TrialType, TrialResult, EventTiming
 export isforced, iswrong, madechoice, .., ms, s
 export parsemat, positive_cells
 

--- a/src/matlab.jl
+++ b/src/matlab.jl
@@ -3,10 +3,10 @@
 #                                 = [2,1]   # animal chose B
 #                                 = [0,1]   # animal made wrong choice during forced choice trial
 #                                 = [0,0]   # animal made no licking responses
-function mat_trialtype(nA, nB, choice, licked)
+function mat_trialresult(nA, nB, choice, licked)
     leftA = nA < 0 || nB > 0
     nA, nB = abs(nA), abs(nB)
-    licked == 0 && return TrialType(nA, nB, leftA, missing)
+    licked == 0 && return TrialResult(nA, nB, leftA, missing)
     if choice == 0
         nA == 0 && nB == 0 && error("double-forced unexpected")
         nA == 0 || nB == 0 || error("expected this to be a forced-choice")
@@ -14,7 +14,7 @@ function mat_trialtype(nA, nB, choice, licked)
     else
         choiceA = choice == 1
     end
-    return TrialType(nA, nB, leftA, choiceA)
+    return TrialResult(nA, nB, leftA, choiceA)
 end
 
 """
@@ -60,9 +60,9 @@ function parsemat(f, filename::AbstractString)
     end
 
     # parse goodtrials (here we assume all trials are listed)
-    tts = Dict{Int,TrialType}()
+    tts = Dict{Int,TrialResult}()
     for r in eachrow(goodtrials)
-        tts[Int(r[1])] = mat_trialtype(r[2:end]...)
+        tts[Int(r[1])] = mat_trialresult(r[2:end]...)
     end
 
     # parse psyphydata

--- a/src/types.jl
+++ b/src/types.jl
@@ -110,7 +110,7 @@ struct TrialType
 end
 
 # This constructor makes it possible to copy/paste the output of the `show` method below
-TrialType(; nA, nB, leftA) = TrialResult(nA, nB, leftA)
+TrialType(; nA, nB, leftA) = TrialType(nA, nB, leftA)
 
 Base.show(io::IO, tt::TrialType) = print(io, "TrialType(nA=", tt.nA, ", nB=", tt.nB, ", leftA=", tt.leftA, ")")
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -98,23 +98,48 @@ end
 
 
 """
-    TrialType(nA, nB, leftA::Bool, choseA::Union{Bool,Missing})
+    TrialType(nA, nB, leftA::Bool)
 
 Encode the offers (`nA` and `nB` are the number of drops of A and B, respectively),
-whether A was on the left, and whether the animal chose A, B, or failed to make a choice
-(`choseA = true | false | missing`, respectively).
+and whether A was on the left.
 """
 struct TrialType
     nA::Int8
     nB::Int8
     leftA::Bool
-    choseA::Union{Bool,Missing}   # missing if the animal didn't lick
 end
 
 # This constructor makes it possible to copy/paste the output of the `show` method below
-TrialType(; nA, nB, leftA, choseA) = TrialType(nA, nB, leftA, choseA)
+TrialType(; nA, nB, leftA) = TrialResult(nA, nB, leftA)
 
-Base.show(io::IO, tt::TrialType) = print(io, "TrialType(nA=", tt.nA, ", nB=", tt.nB, ", leftA=", tt.leftA, ", choseA=", tt.choseA, ")")
+Base.show(io::IO, tt::TrialType) = print(io, "TrialType(nA=", tt.nA, ", nB=", tt.nB, ", leftA=", tt.leftA, ")")
+
+
+"""
+    TrialResult(nA, nB, leftA::Bool, choseA::Union{Bool,Missing})
+    TrialResult(tt::TrialType, choseA::Union{Bool,Missing})
+
+Encode the offer configuration (see [`TrialType`](@ref)), and whether the animal chose A, B, or failed to make a choice
+(`choseA = true | false | missing`, respectively).
+"""
+struct TrialResult
+    tt::TrialType
+    choseA::Union{Bool,Missing}   # missing if the animal didn't lick
+end
+TrialResult(nA, nB, leftA, choseA) = TrialResult(TrialType(nA, nB, leftA), choseA)
+TrialResult(; nA, nB, leftA, choseA) = TrialResult(nA, nB, leftA, choseA)
+
+function Base.getproperty(tr::TrialResult, name::Symbol)
+    name === :nA && return getfield(tr, :tt).nA
+    name === :nB && return getfield(tr, :tt).nB
+    name === :leftA && return getfield(tr, :tt).leftA
+    name === :tt && return getfield(tr, :tt)
+    return getfield(tr, name)
+end
+
+Base.show(io::IO, tr::TrialResult) = print(io, "TrialResult(nA=", tr.nA, ", nB=", tr.nB, ", leftA=", tr.leftA, ", choseA=", tr.choseA, ")")
+
+TrialType(tr::TrialResult) = tr.tt
 
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,22 +6,24 @@ function idxof(list, x)
 end
 
 """
-    madechoice(tt::TrialType)
+    madechoice(tr::TrialResult)
 
 Returns `true` if the animal made a choice in the trial.
 """
-madechoice(tt::TrialType) = tt.choseA !== missing
+madechoice(tr::TrialResult) = tr.choseA !== missing
 
 """
     isforced(tt::TrialType)
+    isforced(tr::TrialResult)
 
 Returns `true` for a forced-choice trial, where either `nA` or `nB` is zero.
 """
 isforced(tt::TrialType) = iszero(tt.nA) ⊻ iszero(tt.nB)
+isforced(tr::TrialResult) = isforced(tr.tt)
 
 """
-    iswrong(tt::TrialType)
+    iswrong(tr::TrialResult)
 
 Returns `true` if `tt` is a forced-choice trial and the animal chose the wrong option.
 """
-iswrong(tt::TrialType) = isforced(tt) && ((iszero(tt.nA) & (tt.choseA===true)) | (iszero(tt.nB) & (tt.choseA===false)))
+iswrong(tr::TrialResult) = isforced(tr) && ((iszero(tr.nA) & (tr.choseA===true)) | (iszero(tr.nB) & (tr.choseA===false)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,24 +39,24 @@ using Documenter
         @test ct[FrameSeq(490ms, 1),:] == (500ms..500ms, dFoF[end:end,:])
     end
 
-    @testset "TrialType" begin
-        tt = TrialType(3, 1, false, true)
-        @test sprint(show, tt) == "TrialType(nA=3, nB=1, leftA=false, choseA=true)"
-        @test eval(Meta.parse("TrialType(nA=3, nB=1, leftA=false, choseA=true)")) == tt
-        @test tt == TrialType(choseA=true, nB=1, nA=3, leftA=false)
-        @test tt != TrialType(3, 1, false, false)
-        @test tt != TrialType(3, 1, false, missing)
-        @test TrialType(3, 1, false, missing) == TrialType(3, 1, false, missing)
-        @test !isforced(tt)
-        @test  madechoice(tt)
-        @test !madechoice(TrialType(3, 1, false, missing))
-        ttf = TrialType(3, 0, false, true)
+    @testset "TrialResult" begin
+        tr = TrialResult(3, 1, false, true)
+        @test sprint(show, tr) == "TrialResult(nA=3, nB=1, leftA=false, choseA=true)"
+        @test eval(Meta.parse("TrialResult(nA=3, nB=1, leftA=false, choseA=true)")) == tr
+        @test tr == TrialResult(choseA=true, nB=1, nA=3, leftA=false)
+        @test tr != TrialResult(3, 1, false, false)
+        @test tr != TrialResult(3, 1, false, missing)
+        @test TrialResult(3, 1, false, missing) == TrialResult(3, 1, false, missing)
+        @test !isforced(tr)
+        @test  madechoice(tr)
+        @test !madechoice(TrialResult(3, 1, false, missing))
+        ttf = TrialResult(3, 0, false, true)
         @test  isforced(ttf)
         @test !iswrong(ttf)
-        ttf = TrialType(3, 0, false, false)
+        ttf = TrialResult(3, 0, false, false)
         @test  isforced(ttf)
         @test  iswrong(ttf)
-        @test !isforced(TrialType(0, 0, false, true))
+        @test !isforced(TrialResult(0, 0, false, true))
     end
 
     @testset "EventTiming" begin
@@ -69,21 +69,21 @@ using Documenter
     end
 
     @testset "Matlab import" begin
-        # Check the "reverse-encoding" of the TrialType
-        @test  EcoTrialStructure.mat_trialtype(1, 1, 1, 1).choseA
-        @test !EcoTrialStructure.mat_trialtype(1, 1, 2, 1).choseA
-        tt = EcoTrialStructure.mat_trialtype(0, 1, 0, 1)
-        @test tt.choseA
-        @test iswrong(tt)
-        @test madechoice(tt)
-        tt = EcoTrialStructure.mat_trialtype(1, 0, 0, 1)
-        @test !tt.choseA
-        @test iswrong(tt)
-        @test madechoice(tt)
-        @test_throws Exception EcoTrialStructure.mat_trialtype(1, 1, 0, 1)
-        @test_throws Exception EcoTrialStructure.mat_trialtype(0, 0, 0, 1)
-        tt = EcoTrialStructure.mat_trialtype(1, 1, 0, 0)
-        @test !madechoice(tt)
+        # Check the "reverse-encoding" of the TrialResult
+        @test  EcoTrialStructure.mat_trialresult(1, 1, 1, 1).choseA
+        @test !EcoTrialStructure.mat_trialresult(1, 1, 2, 1).choseA
+        tr = EcoTrialStructure.mat_trialresult(0, 1, 0, 1)
+        @test tr.choseA
+        @test iswrong(tr)
+        @test madechoice(tr)
+        tr = EcoTrialStructure.mat_trialresult(1, 0, 0, 1)
+        @test !tr.choseA
+        @test iswrong(tr)
+        @test madechoice(tr)
+        @test_throws Exception EcoTrialStructure.mat_trialresult(1, 1, 0, 1)
+        @test_throws Exception EcoTrialStructure.mat_trialresult(0, 0, 0, 1)
+        tr = EcoTrialStructure.mat_trialresult(1, 1, 0, 0)
+        @test !madechoice(tr)
 
         testfile = joinpath(@__DIR__, "data", "testfile.mat")  # snippet from data collected by Manning Zhang, Washington University in St. Louis
         cts, tts, ets = parsemat(testfile)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,6 +45,7 @@ using Documenter
         @test eval(Meta.parse("TrialType(nA=3, nB=1, leftA=false)")) == tt
 
         tr = TrialResult(3, 1, false, true)
+        @test TrialType(tr) == tt
         @test sprint(show, tr) == "TrialResult(nA=3, nB=1, leftA=false, choseA=true)"
         @test eval(Meta.parse("TrialResult(nA=3, nB=1, leftA=false, choseA=true)")) == tr
         @test tr == TrialResult(choseA=true, nB=1, nA=3, leftA=false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,7 +39,11 @@ using Documenter
         @test ct[FrameSeq(490ms, 1),:] == (500ms..500ms, dFoF[end:end,:])
     end
 
-    @testset "TrialResult" begin
+    @testset "TrialType & TrialResult" begin
+        tt = TrialType(3, 1, false)
+        @test sprint(show, tt) == "TrialType(nA=3, nB=1, leftA=false)"
+        @test eval(Meta.parse("TrialType(nA=3, nB=1, leftA=false)")) == tt
+
         tr = TrialResult(3, 1, false, true)
         @test sprint(show, tr) == "TrialResult(nA=3, nB=1, leftA=false, choseA=true)"
         @test eval(Meta.parse("TrialResult(nA=3, nB=1, leftA=false, choseA=true)")) == tr


### PR DESCRIPTION
To support analyses that depend on the trial configuration but not
the animal choice, split the `TrialType` from the `TrialResult`.