### PR TITLE
Deferred `FrameSeq`s

### DIFF
--- a/src/EcoTrialStructure.jl
+++ b/src/EcoTrialStructure.jl
@@ -23,7 +23,7 @@ using OrderedCollections
 using MAT
 
 export CellsTrial, FrameSeq, TrialType, TrialResult, EventTiming
-export isforced, iswrong, madechoice, .., ms, s
+export isdeferred, isforced, iswrong, madechoice, .., ms, s
 export parsemat, positive_cells
 
 include("types.jl")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,6 +6,14 @@ function idxof(list, x)
 end
 
 """
+    isdeferred(fs::FrameSeq)
+
+Return `true` if the start time in `fs` is a field name of `EventTiming`, and hence
+requires concrete instantiation as `fs(et)` for a specific trial.
+"""
+isdeferred(fs::FrameSeq) = isa(fs.start, Symbol)
+
+"""
     madechoice(tr::TrialResult)
 
 Returns `true` if the animal made a choice in the trial.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,7 @@ using Documenter
         @test_throws BoundsError ct[FrameSeq( 80ms, 2),:]   # times must be within the span
         @test_throws BoundsError ct[FrameSeq(470ms, 2),:]
         @test ct[FrameSeq(490ms, 1),:] == (500ms..500ms, dFoF[end:end,:])
+        @test_throws ArgumentError("indexing requires a concrete `FrameSeq`, use `fs(et::EventTiming)`") ct[FrameSeq(:go, 4), :]
     end
 
     @testset "TrialType & TrialResult" begin
@@ -71,6 +72,12 @@ using Documenter
         # Unitful doesn't yet support round-trip printing, see https://github.com/PainterQubits/Unitful.jl/pull/470
         @test_broken eval(Meta.parse("EventTiming(trial_start=0.0f0 ms, offer_on=100.0f0 ms, offer_off=400.0f0 ms, go=450.0f0 ms, choice=837.0f0 ms, trial_end=1200.0f0 ms)")) == et
         @test et.trial_end == 1200ms
+
+        fs = FrameSeq(:go, 5)
+        @test isdeferred(fs)
+        fse = fs(et)
+        @test fse.start == et.go
+        @test fse(EventTiming(0s, 0s, 0s, 0s, 0s, 0s)) == fse   # if the timing is concrete, this doesn't change it
     end
 
     @testset "Matlab import" begin


### PR DESCRIPTION
This supports choosing a generic time marker independent
of specific timing within a trial.