### PR TITLE
Order TrialTypes

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -120,6 +120,9 @@ end
 
 Encode the offers (`nA` and `nB` are the number of drops of A and B, respectively),
 and whether A was on the left.
+
+If you have a list of `TrialType`s, you can `sort` them. High-A trials will come before high-B trials,
+and left before right.
 """
 struct TrialType
     nA::Int8

--- a/src/types.jl
+++ b/src/types.jl
@@ -132,6 +132,19 @@ TrialType(; nA, nB, leftA) = TrialType(nA, nB, leftA)
 
 Base.show(io::IO, tt::TrialType) = print(io, "TrialType(nA=", tt.nA, ", nB=", tt.nB, ", leftA=", tt.leftA, ")")
 
+function Base.isless(a::TrialType, b::TrialType)
+    ratio(tt::TrialType) = tt.nB/tt.nA
+
+    # Ordering puts high-A trials before high-B trials
+    rA, rB = ratio(a), ratio(b)
+    isless(rA, rB) && return true
+    isless(rB, rA) && return false
+    a.nA > b.nA && return true
+    a.nA < b.nA && return false
+    a.nB > b.nB && return false
+    a.nB < b.nB && return true
+    return a.leftA > b.leftA   # if all else are equal, put left before right
+end
 
 """
     TrialResult(nA, nB, leftA::Bool, choseA::Union{Bool,Missing})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,6 +63,31 @@ using Documenter
         @test  isforced(ttf)
         @test  iswrong(ttf)
         @test !isforced(TrialResult(0, 0, false, true))
+
+        # Ordering: useful for printing results along a 1d axis
+        @test !(TrialType(5, 0, false) < TrialType(5, 0, false))
+        @test !(TrialType(5, 0, false) > TrialType(5, 0, false))
+        @test   TrialType(5, 0, false) < TrialType(4, 0, false)
+        @test !(TrialType(5, 0, false) > TrialType(4, 0, false))
+        @test   TrialType(5, 0, false) < TrialType(5, 2, false)
+        @test   TrialType(5, 1, false) > TrialType(5, 0, false)
+
+        @test   TrialType(5, 1, false) < TrialType(5, 2, false)
+        @test !(TrialType(5, 1, false) > TrialType(5, 2, false))
+        @test !(TrialType(5, 1, false) < TrialType(5, 1, false))
+        @test !(TrialType(5, 1, false) > TrialType(5, 1, false))
+
+        @test !(TrialType(0, 5, false) < TrialType(0, 5, false))
+        @test !(TrialType(0, 5, false) > TrialType(0, 5, false))
+        @test   TrialType(0, 5, false) > TrialType(0, 4, false)
+        @test !(TrialType(0, 5, false) < TrialType(0, 4, false))
+        @test   TrialType(0, 5, false) > TrialType(2, 5, false)
+        @test   TrialType(1, 5, false) < TrialType(0, 5, false)
+
+        @test !(TrialType(1, 5, false) < TrialType(1, 5, true))
+        @test   TrialType(1, 5, true)  < TrialType(1, 5, false)
+        @test   TrialType(2, 5, false) < TrialType(1, 5, true)
+        @test   TrialType(2, 5, true)  < TrialType(1, 5, false)
     end
 
     @testset "EventTiming" begin


### PR DESCRIPTION
Defining an order for TrialTypes makes plotting as a function of trial type much nicer, because it keeps similar value-ratios near one another.