### PR TITLE
Support ranges in FrameSeq

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -118,12 +118,14 @@ function Base.getindex(ct::CellsTrial, ti::FrameSeq, ci)
 end
 
 Base.length(fs::FrameSeq) = length(fs.idx)
-Base.axes(fs::FrameSeq) = (fs.idx,)
-Base.axes(fs::FrameSeq, d) = axes(fs)[d]
+Base.axes(fs::FrameSeq) = axes(fs.idx)
+Base.axes(fs::FrameSeq, d) = axes(fs.idx, d)
 
 function Base.checkbounds(::Type{Bool}, ct::CellsTrial, ti::FrameSeq, ci)
-    irange = idxsof(ct.t, ti)
-    checkbounds(Bool, ct.dFoF, irange, ci)
+    r1, r2 = _idxof(ct.t, ti.start)
+    checkbounds(Bool, ct.t, r1) && checkbounds(Bool, ct.t, r2) || return false
+    irange = _idxof(ct.t, ti.start, r1, r2)
+    return checkbounds(Bool, ct.dFoF, irange, ci)
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -5,6 +5,11 @@ function idxof(list, x)
     return x - list[r1] < list[r2] - x ? r1 : r2
 end
 
+function idxsof(list, ti::FrameSeq)
+    istart = idxof(list, ti.start)
+    return istart .+ ti.idx
+end
+
 ncells(ct::CellsTrial) = size(ct.dFoF, 2)
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,9 +1,13 @@
 function idxof(list, x)
+    r1, r2 = _idxof(list, x)
+    return _idxof(list, x, r1, r2)
+end
+function _idxof(list, x)
     r = searchsorted(list, x)
     r1, r2 = first(r), last(r)
-    r1, r2 = min(r1, r2), max(r1, r2)
-    return x - list[r1] < list[r2] - x ? r1 : r2
+    return min(r1, r2), max(r1, r2)
 end
+_idxof(list, x, r1, r2) =  x - list[r1] < list[r2] - x ? r1 : r2
 
 function idxsof(list, ti::FrameSeq)
     istart = idxof(list, ti.start)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,9 +35,15 @@ using Documenter
         @test_throws BoundsError ct[4:6,:]
         @test FrameSeq(100ms, 2) == FrameSeq(100ms, 0:1)
         @test FrameSeq(:go, 2) == FrameSeq(:go, 0:1)
+        fs = FrameSeq(:go, 2)
+        @test length(fs) == 2
+        @test axes(fs) === (Base.OneTo(2),)
+        @test axes(fs, 1) === Base.OneTo(2)
         @test ct[FrameSeq(100ms, 2),:] == ct[FrameSeq(120ms, 2),:] == (100ms..200ms, dFoF[1:2,:])
         @test ct[FrameSeq(200ms, -1:0),:] == (100ms..200ms, dFoF[1:2,:])
         @test ct[FrameSeq(200ms, 2),:] == ct[FrameSeq(220ms, 2),:] == ct[FrameSeq(180ms, 2),:] == (200ms..300ms, dFoF[2:3,:])
+        @test  checkbounds(Bool, ct, FrameSeq(100ms, 2), :)
+        @test !checkbounds(Bool, ct, FrameSeq( 80ms, 2), :)
         @test_throws BoundsError ct[FrameSeq( 80ms, 2),:]   # times must be within the span
         @test_throws BoundsError ct[FrameSeq(470ms, 2),:]
         @test ct[FrameSeq(490ms, 1),:] == (500ms..500ms, dFoF[end:end,:])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,10 @@ using Documenter
         @test_throws BoundsError ct[2:3,3]
         @test_throws BoundsError ct[2:3,0]
         @test_throws BoundsError ct[4:6,:]
+        @test FrameSeq(100ms, 2) == FrameSeq(100ms, 0:1)
+        @test FrameSeq(:go, 2) == FrameSeq(:go, 0:1)
         @test ct[FrameSeq(100ms, 2),:] == ct[FrameSeq(120ms, 2),:] == (100ms..200ms, dFoF[1:2,:])
+        @test ct[FrameSeq(200ms, -1:0),:] == (100ms..200ms, dFoF[1:2,:])
         @test ct[FrameSeq(200ms, 2),:] == ct[FrameSeq(220ms, 2),:] == ct[FrameSeq(180ms, 2),:] == (200ms..300ms, dFoF[2:3,:])
         @test_throws BoundsError ct[FrameSeq( 80ms, 2),:]   # times must be within the span
         @test_throws BoundsError ct[FrameSeq(470ms, 2),:]


### PR DESCRIPTION
Sometimes you'd like to grab frames that occur before a trigger, in which case `FrameSeq(:go, -3:7)` is an attractive syntax.