### PR TITLE
Use offset indices for dFoF

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 MAT = "23992714-dd62-5051-b70f-ba57cb901cac"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -59,7 +59,7 @@ FrameSeq(:offer_on, -2:7)
 julia> dFoFs = [cts[trialindex][fs(et), :][2] for (trialindex, et) in ets];
 
 julia> dFoFs[1]   # trial 3
-10×63 Matrix{Float64}:
+10×63 OffsetArray(::Matrix{Float64}, -2:7, 1:63) with eltype Float64 with indices -2:7×1:63:
  0.146783   0.479383  0.598108  …  0.0408331   0.0357164   0.0741511
  0.177113   0.481758  0.579934     0.0181103   0.029064    0.0962147
  0.158358   0.318992  0.679291     0.0356008  -0.0285638   0.242723

--- a/src/EcoTrialStructure.jl
+++ b/src/EcoTrialStructure.jl
@@ -20,6 +20,7 @@ module EcoTrialStructure
 using Unitful
 using Unitful: ms, s
 using IntervalSets
+using OffsetArrays
 using OrderedCollections
 using MAT
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -43,7 +43,7 @@ julia> tframes
 200.0f0 ms..400.0f0 ms
 
 julia> df
-3×2 Matrix{Float64}:
+3×2 OffsetArray(::Matrix{Float64}, 0:2, 1:2) with eltype Float64 with indices 0:2×1:2:
  -0.1  0.7
   0.2  0.6
   0.1  0.5
@@ -127,14 +127,14 @@ function Base.getindex(ct::CellsTrial, ti::FrameSeq, ci)
 end
 
 Base.length(fs::FrameSeq) = length(fs.idx)
-Base.axes(fs::FrameSeq) = axes(fs.idx)
-Base.axes(fs::FrameSeq, d) = axes(fs.idx, d)
+Base.axes(fs::FrameSeq) = (Base.IdentityUnitRange(fs.idx),)
+Base.axes(fs::FrameSeq, d) = axes(fs)[d]
 
 function Base.checkbounds(::Type{Bool}, ct::CellsTrial, ti::FrameSeq, ci)
     r1, r2 = _idxof(ct.t, ti.start)
     checkbounds(Bool, ct.t, r1) && checkbounds(Bool, ct.t, r2) || return false
-    irange = _idxof(ct.t, ti.start, r1, r2)
-    return checkbounds(Bool, ct.dFoF, irange, ci)
+    istart = _idxof(ct.t, ti.start, r1, r2)
+    return checkbounds(Bool, ct.dFoF, istart .+ ti.idx, ci)
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -11,7 +11,7 @@ _idxof(list, x, r1, r2) =  x - list[r1] < list[r2] - x ? r1 : r2
 
 function idxsof(list, ti::FrameSeq)
     istart = idxof(list, ti.start)
-    return istart .+ ti.idx
+    return OffsetArrays.IdOffsetRange(values=istart .+ ti.idx, indices=ti.idx)
 end
 
 """


### PR DESCRIPTION
It seems best to have `ct[fs,:]` preserve the offset-relative-to-trigger indices in `fs`. This reworks the axis-handling accordingly.