### PR TITLE
Add ordering for TrialResult

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -155,6 +155,8 @@ end
 # This constructor makes it possible to copy/paste the output of the `show` method below
 TrialType(; nA, nB, leftA) = TrialType(nA, nB, leftA)
 
+TrialType(tt::TrialType) = tt
+
 Base.show(io::IO, tt::TrialType) = print(io, "TrialType(nA=", tt.nA, ", nB=", tt.nB, ", leftA=", tt.leftA, ")")
 
 function Base.isless(a::TrialType, b::TrialType)
@@ -184,6 +186,7 @@ struct TrialResult
 end
 TrialResult(nA, nB, leftA, choseA) = TrialResult(TrialType(nA, nB, leftA), choseA)
 TrialResult(; nA, nB, leftA, choseA) = TrialResult(nA, nB, leftA, choseA)
+TrialResult(tr::TrialResult) = tr
 
 function Base.getproperty(tr::TrialResult, name::Symbol)
     name === :nA && return getfield(tr, :tt).nA
@@ -196,6 +199,15 @@ end
 Base.show(io::IO, tr::TrialResult) = print(io, "TrialResult(nA=", tr.nA, ", nB=", tr.nB, ", leftA=", tr.leftA, ", choseA=", tr.choseA, ")")
 
 TrialType(tr::TrialResult) = tr.tt
+
+function Base.isless(a::TrialResult, b::TrialResult)
+    tta, ttb = TrialType(a), TrialType(b)
+    isless(tta, ttb) && return true
+    isless(ttb, tta) && return false
+    # This implements `true` > `missing` > `false` logic
+    rank(choice) = isa(choice, Bool) ? Float64(choice) : 0.5
+    return isless(rank(b.choseA), rank(a.choseA))
+end
 
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -68,10 +68,12 @@ using Documenter
 
     @testset "TrialType & TrialResult" begin
         tt = TrialType(3, 1, false)
+        @test TrialType(tt) === tt
         @test sprint(show, tt) == "TrialType(nA=3, nB=1, leftA=false)"
         @test eval(Meta.parse("TrialType(nA=3, nB=1, leftA=false)")) == tt
 
         tr = TrialResult(3, 1, false, true)
+        @test TrialResult(tr) === tr
         @test TrialType(tr) == tt
         @test sprint(show, tr) == "TrialResult(nA=3, nB=1, leftA=false, choseA=true)"
         @test eval(Meta.parse("TrialResult(nA=3, nB=1, leftA=false, choseA=true)")) == tr
@@ -114,6 +116,13 @@ using Documenter
         @test   TrialType(1, 5, true)  < TrialType(1, 5, false)
         @test   TrialType(2, 5, false) < TrialType(1, 5, true)
         @test   TrialType(2, 5, true)  < TrialType(1, 5, false)
+
+        for (a, b) in ((true, true), (true, false), (false, true), (false, false), (true, missing), (missing, true))
+            @test TrialResult(5, 1, false, a) < TrialResult(5, 2, false, b)    # TrialType trumps choice
+        end
+        tt = TrialType(5, 1, false)
+        @test TrialResult(tt, true) < TrialResult(tt, missing) < TrialResult(tt, false)
+        @test !(TrialResult(tt, true) < TrialResult(tt, true))
     end
 
     @testset "EventTiming" begin


### PR DESCRIPTION
This allows the behavior choice to influence ordering of sequence
of offer types.

Also make constructors idempotent, to facilitate
conversion or lack thereof.