### PR TITLE
Revert "CompatHelper: bump compat for IntervalSets to 0.7, (keep existing compat)"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
-IntervalSets = "0.5, 0.6, 0.7"
+IntervalSets = "0.5, 0.6"
 MAT = "0.10"
 OffsetArrays = "1"
 OrderedCollections = "1"


### PR DESCRIPTION
Reverts HolyLab/EcoTrialStructure.jl#17